### PR TITLE
Pass component name to Connect

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "version": "1.0.1",
   "author": "Henrik Joreteg <henrik@joreteg.com> (joreteg.com)",
   "devDependencies": {
-    "microbundle": "0.4.0",
-    "react": "16.2.0",
-    "react-dom": "16.2.0",
-    "redux-bundler": "16.0.0",
-    "tap-spec": "4.1.1",
-    "tape": "4.8.0"
+    "microbundle": "0.6.0",
+    "react": "16.5.2",
+    "react-dom": "16.5.2",
+    "redux-bundler": "22.2.0",
+    "tap-spec": "5.0.0",
+    "tape": "4.9.1"
   },
   "keywords": [
     "react",

--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,6 @@ export const connect = (...args) => {
     }
   }
   Connect.contextTypes = CONTEXT_TYPES
-
+  Connect.displayName = Component.displayName || Component.name
   return Connect
 }


### PR DESCRIPTION
### What this does

Often I would run into issues when I was debugging with react-dev-tools or other tools that log components out, and any connected component would be displayed as `<o>`. This PR passes along the wrapped components name to `Connect`.

cc @HenrikJoreteg 